### PR TITLE
fsck.auto: use lsblk or blkid and check for their which

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2020, Suchao Wang aka blaider@github 
+Copyright (c) 2023, Roberto A. Foglietta <roberto.foglietta@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# This is a simple bash script for busybox fsck.auto to 
-# check block device partition file system type
+## Description
+
+This is a simple b/ash script for busybox fsck.auto to check block device partition file system type

--- a/fsck.auto
+++ b/fsck.auto
@@ -25,7 +25,7 @@ if [ "x$DEVNODE" = "x" ]; then
     exit 1
 fi
 if which lsblk >/dev/null; then
-    FSTYPE=$(command lsblk -f "$DEVNODE" | tail -1 | awk '{print $2}')
+    FSTYPE=$(command lsblk -f "$DEVNODE" -ro FSTYPE | grep -v FSTYPE)
 elif which blkid >/dev/null; then
     FSTYPE=$(command blkid -p "$DEVNODE" -o full | sed -ne 's/.* TYPE="\([^"]*\)" .*/\1/p')
 else

--- a/fsck.auto
+++ b/fsck.auto
@@ -1,4 +1,11 @@
 #!/bin/bash
+#
+# Copyright (c) 2020, Suchao Wang aka blaider@github
+# Copyright (c) 2023, Roberto A. Foglietta <roberto.foglietta@gmail.com>
+#                     Released under MIT license terms
+#
+#i#############################################################################
+
 #echo "params: '$*'" #debug
 
 export PATH=${PATH:-/bin:/usr/bin:/usr/local/bin:/sbin:/usr/sbin:/usr/local/sbin}

--- a/fsck.auto
+++ b/fsck.auto
@@ -1,38 +1,40 @@
 #!/bin/bash
-#echo $*
+#echo "params: '$*'" #debug
 
 export PATH=${PATH:-/bin:/usr/bin:/usr/local/bin:/sbin:/usr/sbin:/usr/local/sbin}
 
 if ! which which >/dev/null; then
     which() { 
-        for i in $(echo $PATH | tr : ' '); do
-            if [ -x $i/$1 ]; then echo $i/$1; return 0; fi;
+        for i in $(echo "$PATH" | tr : ' '); do
+            if [ -x "$i/$1" ]; then echo "$i/$1"; return 0; fi;
         done
         return 1
     }
 fi
 
 for idx in 0 $(seq $#); do
-    name=`eval echo -n "$"$idx`
-    if [ -b $name ];then
-	DEVNODE=$name
+    name=$(eval echo -n "\$$idx")
+    if [ -b "$name" ]; then
+	DEVNODE="$name"
     fi
 done
-#echo $DEVNODE
-if [ "$DEVNODE"x == ""x ];then
+
+#echo "devnode: '$DEVNODE'" #debug
+if [ "x$DEVNODE" = "x" ]; then
     echo "device find error"
     exit 1
 fi
 if which lsblk >/dev/null; then
-    FSTYPE=$(lsblk -f $DEVNODE | tail -1 | awk '{print $2}')
+    FSTYPE=$(lsblk -f "$DEVNODE" | tail -1 | awk '{print $2}')
 elif which blkid >/dev/null; then
-    FSTYPE=$(blkid $DEVNODE | sed -ne 's/.* TYPE="\([^"]*\)" .*/\1/p')
+    FSTYPE=$(blkid "$DEVNODE" | sed -ne 's/.* TYPE="\([^"]*\)" .*/\1/p')
 else
-    echo "ERROR: lsblk or blkid is required, abort"
+    echo "ERROR: lsblk and blkid missing but one of them is required, abort"
     exit 1
 fi
-#echo $DEVNODE  $FSTYPE
-CMD=fsck."${FSTYPE}"
-echo $CMD $*
-$CMD $*
+
+#echo "devnode: '$DEVNODE', fstype: '$FSTYPE'" #debug
+CMD="fsck.${FSTYPE}"
+echo "executing: '$CMD $*'"
+eval $CMD $*
 exit $?

--- a/fsck.auto
+++ b/fsck.auto
@@ -3,6 +3,15 @@
 
 export PATH=${PATH:-/bin:/usr/bin:/usr/local/bin:/sbin:/usr/sbin:/usr/local/sbin}
 
+if ! which which >/dev/null; then
+    which() { 
+        for i in $(echo $PATH | tr : ' '); do
+            if [ -x $i/$1 ]; then echo $i/$1; return 0; fi;
+        done
+        return 1
+    }
+fi
+
 for idx in 0 $(seq $#); do
     name=`eval echo -n "$"$idx`
     if [ -b $name ];then

--- a/fsck.auto
+++ b/fsck.auto
@@ -1,5 +1,8 @@
 #!/bin/bash
 #echo $*
+
+export PATH=${PATH:-/bin:/usr/bin:/usr/local/bin:/sbin:/usr/sbin:/usr/local/sbin}
+
 for idx in 0 $(seq $#); do
     name=`eval echo -n "$"$idx`
     if [ -b $name ];then

--- a/fsck.auto
+++ b/fsck.auto
@@ -25,9 +25,9 @@ if [ "x$DEVNODE" = "x" ]; then
     exit 1
 fi
 if which lsblk >/dev/null; then
-    FSTYPE=$(lsblk -f "$DEVNODE" | tail -1 | awk '{print $2}')
+    FSTYPE=$(command lsblk -f "$DEVNODE" | tail -1 | awk '{print $2}')
 elif which blkid >/dev/null; then
-    FSTYPE=$(blkid "$DEVNODE" | sed -ne 's/.* TYPE="\([^"]*\)" .*/\1/p')
+    FSTYPE=$(command blkid -p "$DEVNODE" -o full | sed -ne 's/.* TYPE="\([^"]*\)" .*/\1/p')
 else
     echo "ERROR: lsblk and blkid missing but one of them is required, abort"
     exit 1

--- a/fsck.auto
+++ b/fsck.auto
@@ -11,7 +11,14 @@ if [ "$DEVNODE"x == ""x ];then
     echo "device find error"
     exit 1
 fi
-FSTYPE=`lsblk -f $DEVNODE | tail -1 | awk '{print $2}'`
+if which lsblk >/dev/null; then
+    FSTYPE=$(lsblk -f $DEVNODE | tail -1 | awk '{print $2}')
+elif which blkid >/dev/null; then
+    FSTYPE=$(blkid $DEVNODE | sed -ne 's/.* TYPE="\([^"]*\)" .*/\1/p')
+else
+    echo "ERROR: lsblk or blkid is required, abort"
+    exit 1
+fi
 #echo $DEVNODE  $FSTYPE
 CMD=fsck."${FSTYPE}"
 echo $CMD $*


### PR DESCRIPTION
In some Android boot images the `lsblk` command is not present but `blkid` which can deliver the same result with an appropriate `sed` in pipe. Moreover, in general also `which` may not be available, even if it is improbable it is not impossible. If which sh would fail, the it is necessary to define a function `which()` that search for `$1` into every folder in `$PATH`. If also `$PATH` is not defined then a standard definition should be given like

`export PATH=${PATH:-/bin:/usr/bin:/usr/local/bin:/sbin:/usr/sbin:/usr/local/sbin}`.

This will go into the next commit.